### PR TITLE
Packing fraction -> volume fraction

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,14 +37,9 @@ repos:
     hooks:
       - id: nbqa-pyupgrade
         args:
-          - --nbqa-mutate
           - --py36-plus
       - id: nbqa-isort
-        args:
-          - --nbqa-mutate
       - id: nbqa-yapf
-        args:
-          - --nbqa-mutate
   - repo: https://github.com/kynan/nbstripout
     rev: 0.5.0
     hooks:

--- a/00-Introducing-HOOMD-blue/00-index.ipynb
+++ b/00-Introducing-HOOMD-blue/00-index.ipynb
@@ -27,7 +27,7 @@
     "2. [Performing Hard Particle Monte Carlo Simulations](02-Performing-Hard-Particle-Monte-Carlo-Simulations.ipynb) - What is hard particle Monte Carlo? How do I set up a hard particle Monte Carlo simulation?\n",
     "3. [Initializing the System State](03-Initializing-the-System-State.ipynb) - How do I place particles in the initial condition? What units does HOOMD-blue use?\n",
     "4. [Randomizing the System](04-Randomizing-the-System.ipynb) - How can I generate a random initial condition?\n",
-    "5. [Compressing the System](05-Compressing-the-System.ipynb) - How do I compress the system to a target density? What is a packing fraction?\n",
+    "5. [Compressing the System](05-Compressing-the-System.ipynb) - How do I compress the system to a target density? What is a volume fraction?\n",
     "6. [Equilibrating the System](06-Equilibrating-the-System.ipynb) - What is equilibration? How do I save simulation results?\n",
     "7. [Analyzing Trajectories](07-Analyzing-Trajectories.ipynb) - How can I analyze trajectories?\n"
    ]
@@ -51,7 +51,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -65,7 +65,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.2"
+   "version": "3.9.7"
   },
   "record_timing": false
  },

--- a/00-Introducing-HOOMD-blue/05-Compressing-the-System.ipynb
+++ b/00-Introducing-HOOMD-blue/05-Compressing-the-System.ipynb
@@ -11,13 +11,13 @@
     "### Questions\n",
     "\n",
     "* How do I compress the system to a target density? \n",
-    "* What is a packing fraction?\n",
+    "* What is a volume fraction?\n",
     "\n",
     "### Objectives\n",
     "\n",
-    "* Show how to compute the **packing fraction** of a system.\n",
+    "* Show how to compute the **volume fraction** of a system.\n",
     "* Explain how how an **Updater** is an **operation** that modifies the system when its **Trigger** returns `True`.\n",
-    "* Demonstrate using the **QuickCompress** updater to achieve a target packing fraction.\n",
+    "* Demonstrate using the **QuickCompress** updater to achieve a target volume fraction.\n",
     "* Demonstrate using the **MoveSize** tuner to adjust the trial move size.\n",
     "\n",
     "## Boilerplate code"
@@ -141,13 +141,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Packing fraction\n",
+    "## Volume fraction\n",
     "\n",
-    "Self-assembly in hard particle systems typically occurs at a **packing fraction** above 0.5.\n",
-    "The **packing fraction** is the ratio of the volume occupied by the particles to the volume of the **periodic box**.\n",
+    "Self-assembly in hard particle systems typically occurs at a **volume fraction** above 0.5.\n",
+    "The **volume fraction** is the ratio of the volume occupied by the particles to the volume of the **periodic box**.\n",
     "\n",
-    "So far, this tutorial as **randomized** a system of *N* octahedra in a box with a very low packing fraction and stored that in `random.gsd`.\n",
-    "Initialize a **Simulation** with this configuration and see what packing fraction it is at:"
+    "So far, this tutorial as **randomized** a system of *N* octahedra in a box with a very low volume fraction and stored that in `random.gsd`.\n",
+    "Initialize a **Simulation** with this configuration and see what volume fraction it is at:"
    ]
   },
   {
@@ -182,7 +182,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Compute the **packing fraction**:"
+    "Compute the **volume fraction**:"
    ]
   },
   {
@@ -199,16 +199,16 @@
     }
    ],
    "source": [
-    "initial_packing_fraction = (sim.state.N_particles * V_particle\n",
-    "                            / sim.state.box.volume)\n",
-    "print(initial_packing_fraction)"
+    "initial_volume_fraction = (sim.state.N_particles * V_particle\n",
+    "                           / sim.state.box.volume)\n",
+    "print(initial_volume_fraction)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As you can see, this **packing fraction** is very low and the box volume needs to be significantly reduced to achieve a **packing fraction** above 0.5."
+    "As you can see, this **volume fraction** is very low and the box volume needs to be significantly reduced to achieve a **volume fraction** above 0.5."
    ]
   },
   {
@@ -253,7 +253,7 @@
     "It then waits for the translation and rotation **trial moves** to remove these overlaps before it reduces the volume again.\n",
     "This process temporarily produces invalid system configurations, but is much quicker than a process that does not allow temporary overlaps.\n",
     "\n",
-    "Compute the final box size with a **packing fraction** above 0.5 and configure a **QuickCompress** to **trigger** every 10 **time steps**."
+    "Compute the final box size with a **volume fraction** above 0.5 and configure a **QuickCompress** to **trigger** every 10 **time steps**."
    ]
   },
   {
@@ -264,8 +264,8 @@
    "source": [
     "initial_box = sim.state.box\n",
     "final_box = hoomd.Box.from_box(initial_box)\n",
-    "final_packing_fraction = 0.57\n",
-    "final_box.volume = sim.state.N_particles * V_particle / final_packing_fraction\n",
+    "final_volume_fraction = 0.57\n",
+    "final_box.volume = sim.state.N_particles * V_particle / final_volume_fraction\n",
     "compress = hoomd.hpmc.update.QuickCompress(trigger=hoomd.trigger.Periodic(10),\n",
     "                                           target_box=final_box)"
    ]
@@ -488,7 +488,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -502,7 +502,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "version": "3.9.7"
   },
   "record_timing": false
  },

--- a/00-Introducing-HOOMD-blue/06-Equilibrating-the-System.ipynb
+++ b/00-Introducing-HOOMD-blue/06-Equilibrating-the-System.ipynb
@@ -142,7 +142,7 @@
    "source": [
     "## Equilibration\n",
     "\n",
-    "So far, this tutorial has placed *N* non-overlapping octahedra randomly in a box and then compressed it to a moderate packing fraction.\n",
+    "So far, this tutorial has placed *N* non-overlapping octahedra randomly in a box and then compressed it to a moderate volume fraction.\n",
     "The resulting configuration of particles is valid, but strongly dependent on the path taken to create it.\n",
     "There are many more **equilibrium** configurations in the set of possible configurations that do not depend on the path.\n",
     "**Equilibrating** the system is the process of taking an artificially prepared state and running a simulation.\n",
@@ -384,7 +384,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -398,7 +398,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "version": "3.9.7"
   },
   "record_timing": false
  },

--- a/00-Introducing-HOOMD-blue/07-Analyzing-Trajectories.ipynb
+++ b/00-Introducing-HOOMD-blue/07-Analyzing-Trajectories.ipynb
@@ -250,8 +250,8 @@
     "## Ergodicity\n",
     "\n",
     "A system is *ergodic* when it can explore all possible states by making small moves from one to another.\n",
-    "In HPMC simulations, low packing fraction simulations are ergodic while very high packing fraction ones are not.\n",
-    "At high packing fractions, there isn't enough free space for the particles to rearrange so they get stuck in local configurations.\n",
+    "In HPMC simulations, low volume fraction simulations are ergodic while very high volume fraction ones are not.\n",
+    "At high volume fractions, there isn't enough free space for the particles to rearrange so they get stuck in local configurations.\n",
     "\n",
     "Visualize the motion of just a few particles to see if they appear stuck or if they are freely moving about the box:"
    ]
@@ -433,7 +433,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -447,7 +447,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "version": "3.9.7"
   },
   "record_timing": false
  },


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
Replace the term "packing fraction" with "volume fraction".

I mistakenly used the old term out of habit. In modern usage, "packing fraction" only applies to systems at putative densest packings. This tutorial runs simulations at self-assembly volume fractions.

In an unrelated change, I removed the `--nbqa-mutate` option as pre-commit informed me that:
> Flag --nbqa-mutate was deprecated in 1.0.0 and is now unnecessary   

Resolves #56 

## Checklist:
- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-examples/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-examples/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of authors](https://github.com/glotzerlab/hoomd-examples/blob/master/AUTHORS.md).
