### PR TITLE
Use non-deprecated Pillow APIs.

### DIFF
--- a/00-Introducing-HOOMD-blue/07-Analyzing-Trajectories.ipynb
+++ b/00-Introducing-HOOMD-blue/07-Analyzing-Trajectories.ipynb
@@ -145,9 +145,8 @@
     "        is_solid = [None] * len(frames)\n",
     "    a = render(frames[0], particles, is_solid[0])\n",
     "\n",
-    "    im0 = PIL.Image.fromarray(a[:, :, 0:3],\n",
-    "                              mode='RGB').convert(\"P\",\n",
-    "                                                  palette=PIL.Image.ADAPTIVE)\n",
+    "    im0 = PIL.Image.fromarray(a[:, :, 0:3], mode='RGB').convert(\n",
+    "        \"P\", palette=PIL.Image.Palette.ADAPTIVE)\n",
     "    ims = []\n",
     "    for i, f in enumerate(frames[1:]):\n",
     "        a = render(f, particles, is_solid[i])\n",
@@ -447,7 +446,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.13"
   },
   "record_timing": false
  },


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
Replace the deprecated `PIL.Image.ADAPTIVE` with `PIL.Image.Palette.ADAPTIVE`. This removes the warning message presented to users when they run the notebook with a current Pillow install.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves: #64.

## Checklist:
- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-examples/blob/trunk/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-examples/blob/trunk/ContributorAgreement.md).
- [x] My name is on the [list of authors](https://github.com/glotzerlab/hoomd-examples/blob/trunk/AUTHORS.md).
