### PR TITLE
Fix failing unit tests.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,7 +84,7 @@ jobs:
       run: ls **/*.ipynb
       working-directory: notebooks
     - name: Execute notebooks
-      run: jupyter nbconvert --execute --inplace **/*.ipynb
+      run: 'for i in **; do echo "Running notebooks in: $i" && jupyter nbconvert --execute --inplace $i/*.ipynb || exit 1; done'
       working-directory: notebooks
       env:
         PYTHONPATH: ${{ github.workspace }}/hoomd/build


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
Use a for loop to run nbconvert once in each directory.

For unknown reasons, the behavior of nbconvert changed preventing the use of `**/*.ipynb` in one call. It reported:
```
ValueError: Conversion would override an already generated output. This is probably due to --output or output_base configuration leading to non-unique output names. Output notebook names were: ['00-index', '01-The-Simulation-Object', '02-Performing-Hard-Particle-Monte-Carlo-Simulations', '03-Initializing-the-System-State', '04-Randomizing-the-System', '05-Compressing-the-System', '06-Equilibrating-the-System', '07-Analyzing-Trajectories', '00-index', '01-Molecular-Dynamics-Simulations', '02-Initializing-a-Random-System', '03-Compressing-the-System', '00-index', '01-Logging-to-a-GSD-file', '02-Saving-Array-Quantities', '03-Storing-Particle-Shape', '04-Writing-Formatted-Output', '00-index', '01-Introduction-to-MPI', '02-Domain-Decomposition', '03-Accessing-System-Configurations-With-MPI', '04-Running-Multiple-Simulations-With-Partitions', '00-index', '01-What-are-Actions', '02-An-Initial-Custom-Action', '03-Custom-Action-Features', '04-Custom-Updater', '05-Custom-Writer', '06-Improving-Performance', '00-index', '01-Organizing-Data', '02-Executing-Simulations', '03-Continuing-Simulations', '04-Submitting-Cluster-Jobs', '00-index', '01-Introduction-to-Rigid-Bodies', '02-Running-Rigid-Body-Simulations', '03-Preparing-a-General-Body', '00-index', '01-Kern-Frenkel-Model', '02-Simulating-a-System-of-Patchy-Particles', 'create-figures']
```

## Checklist:
- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-examples/blob/trunk/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-examples/blob/trunk/ContributorAgreement.md).
- [x] My name is on the [list of authors](https://github.com/glotzerlab/hoomd-examples/blob/trunk/AUTHORS.md).
