### PR TITLE
Fix compile error in CPPPotential example with some compilers.

### DIFF
--- a/07-Modelling-Patchy-Particles/02-Simulating-a-System-of-Patchy-Particles.ipynb
+++ b/07-Modelling-Patchy-Particles/02-Simulating-a-System-of-Patchy-Particles.ipynb
@@ -261,7 +261,7 @@
    "outputs": [],
    "source": [
     "patch_code += f\"\"\"\n",
-    "vec3<float> r_hat_ij = r_ij / sqrt(dot(r_ij, r_ij));\n",
+    "vec3<float> r_hat_ij = r_ij / sqrtf(dot(r_ij, r_ij));\n",
     "bool patch_on_i_is_aligned_with_r_ij = dot(ehat_i, r_hat_ij) >= cos(delta);\n",
     "bool patch_on_j_is_aligned_with_r_ji = dot(ehat_j, -r_hat_ij) >= cos(delta);\n",
     "\"\"\""
@@ -289,7 +289,7 @@
    "source": [
     "patch_code += f\"\"\"\n",
     "float rsq = dot(r_ij, r_ij);\n",
-    "float r_ij_length = sqrt(rsq);\n",
+    "float r_ij_length = sqrtf(rsq);\n",
     "if (patch_on_i_is_aligned_with_r_ij\n",
     "    && patch_on_j_is_aligned_with_r_ji\n",
     "    && r_ij_length < lambda*sigma)\n",


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
Replace `sqrt` with `sqrtf` when computing the square root with a desired `float` output type.

## Checklist:
- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-examples/blob/trunk/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-examples/blob/trunk/ContributorAgreement.md).
- [x] My name is on the [list of authors](https://github.com/glotzerlab/hoomd-examples/blob/trunk/AUTHORS.md).
