### PR TITLE
MPCD examples: fix the link in index to second example

### DIFF
--- a/09-Multiparticle-Collision-Dynamics/00-index.ipynb
+++ b/09-Multiparticle-Collision-Dynamics/00-index.ipynb
@@ -33,7 +33,7 @@
     "## Outline\n",
     "\n",
     "1. [Pressure-Driven Flow Between Parallel Plates](01-Pressure-Driven-Flow.ipynb)\n",
-    "2. [Diffusion of a Solution of Nearly-Hard Spheres](02-Diffusion.ipynb)\n",
+    "2. [Diffusion of a Solution of Nearly-Hard Spheres](02-Diffusion-in-Solution.ipynb)\n",
     "\n"
    ]
   },


### PR DESCRIPTION
## Description

When adding the MPCD examples to the HOOMD documentation, I noticed that the link to the second example in the index referred to an old file name. This corrects that mistake. 

Resolves: N/A

## Checklist:
- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-examples/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-examples/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the [list of authors](https://github.com/glotzerlab/hoomd-examples/blob/trunk-minor/AUTHORS.md).
